### PR TITLE
Add dynamic Home Assistant sensor export

### DIFF
--- a/multiformat_logger/config.yaml
+++ b/multiformat_logger/config.yaml
@@ -1,0 +1,4 @@
+# Configuration for sensor export
+ha_url: http://homeassistant.local:8123
+api_token: YOUR_LONG_LIVED_TOKEN
+output_csv: sensors.csv

--- a/multiformat_logger/requirements.txt
+++ b/multiformat_logger/requirements.txt
@@ -1,1 +1,4 @@
 click
+pandas
+pyyaml
+requests

--- a/multiformat_logger/src/sensor_exporter.py
+++ b/multiformat_logger/src/sensor_exporter.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List, Any
+
+import requests
+
+import pandas as pd
+import yaml
+
+
+DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[1] / "config.yaml"
+
+
+def load_config(path: Path = DEFAULT_CONFIG_PATH) -> Dict[str, Any]:
+    """Load YAML configuration."""
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def get_states(base_url: str, token: str) -> List[Dict[str, Any]]:
+    """Return all entity states from Home Assistant."""
+    url = f"{base_url.rstrip('/')}/api/states"
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    resp = requests.get(url, headers=headers, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_history(base_url: str, token: str, entity_id: str) -> List[Dict[str, Any]]:
+    """Return history for a single entity."""
+    url = f"{base_url.rstrip('/')}/api/history/period"
+    params = {"filter_entity_id": entity_id}
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    resp = requests.get(url, params=params, headers=headers, timeout=10)
+    resp.raise_for_status()
+    result = resp.json()
+    if not result:
+        return []
+    values = []
+    for item in result[0]:
+        value = item["state"]
+        try:
+            value = float(value)
+        except ValueError:
+            pass
+        values.append({"timestamp": item["last_changed"], "value": value})
+    return values
+
+
+def load_sensor_data(base_url: str, token: str) -> Dict[str, List[Dict[str, Any]]]:
+    """Retrieve data for all sensors from Home Assistant."""
+    states = get_states(base_url, token)
+    data: Dict[str, List[Dict[str, Any]]] = {}
+    for state in states:
+        entity_id = state.get("entity_id", "")
+        if not entity_id.startswith("sensor."):
+            continue
+        history = get_history(base_url, token, entity_id)
+        if history:
+            data[entity_id] = history
+    return data
+
+
+def build_dataframe(data: Dict[str, List[Dict[str, Any]]]) -> pd.DataFrame:
+    """Create dataframe with unified timestamp index from sensor data."""
+    df: pd.DataFrame | None = None
+    for name, entries in data.items():
+        sensor_df = pd.DataFrame(entries)
+        sensor_df["timestamp"] = pd.to_datetime(sensor_df["timestamp"], utc=True)
+        sensor_df = sensor_df.rename(columns={"value": name})
+        sensor_df = sensor_df[["timestamp", name]]
+        if df is None:
+            df = sensor_df
+        else:
+            df = pd.merge(df, sensor_df, on="timestamp", how="outer")
+    assert df is not None
+    df = df.sort_values("timestamp").set_index("timestamp")
+    return df
+
+
+def export(config_path: Path = DEFAULT_CONFIG_PATH) -> pd.DataFrame:
+    """Export sensors defined in the configuration to CSV."""
+    config = load_config(config_path)
+    base_url = config["ha_url"]
+    token = config["api_token"]
+    output_path = Path(config["output_csv"])
+
+    data = load_sensor_data(base_url, token)
+    df = build_dataframe(data)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(output_path)
+    return df
+
+
+if __name__ == "__main__":
+    export()

--- a/tests/test_sensor_exporter.py
+++ b/tests/test_sensor_exporter.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+import pandas as pd
+
+from multiformat_logger.src import sensor_exporter
+from multiformat_logger.src.sensor_exporter import export
+
+
+def test_export_creates_csv(tmp_path: Path, monkeypatch):
+    def fake_get_states(base_url: str, token: str):
+        return [
+            {"entity_id": "sensor.temperature"},
+            {"entity_id": "sensor.humidity"},
+            {"entity_id": "light.kitchen"},
+        ]
+
+    def fake_get_history(base_url: str, token: str, entity_id: str):
+        if entity_id == "sensor.temperature":
+            return [
+                {"timestamp": "2023-01-01T00:00:00Z", "value": 20},
+                {"timestamp": "2023-01-01T01:00:00Z", "value": 21},
+            ]
+        elif entity_id == "sensor.humidity":
+            return [
+                {"timestamp": "2023-01-01T00:30:00Z", "value": 50},
+                {"timestamp": "2023-01-01T01:00:00Z", "value": 55},
+            ]
+        return []
+
+    monkeypatch.setattr(sensor_exporter, "get_states", fake_get_states)
+    monkeypatch.setattr(sensor_exporter, "get_history", fake_get_history)
+
+    output_csv = tmp_path / "out.csv"
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        f"ha_url: http://localhost\napi_token: token\noutput_csv: {output_csv}\n"
+    )
+
+    df = export(config_path=config_file)
+
+    assert output_csv.exists()
+    csv_df = pd.read_csv(output_csv)
+    # DataFrame should have same rows as returned df
+    assert len(csv_df) == len(df)
+    assert "sensor.temperature" in csv_df.columns
+    assert "sensor.humidity" in csv_df.columns


### PR DESCRIPTION
## Summary
- support fetching sensors via Home Assistant REST API
- update config to specify Home Assistant URL and token
- adjust tests to mock API calls
- drop bundled `sensors.json` sample data
- include `requests` dependency

## Testing
- `pytest -q` *(fails: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_688a6ffd7ea08320a44ff53001a3c388